### PR TITLE
fix definition of letterbox-face

### DIFF
--- a/letterbox-mode.el
+++ b/letterbox-mode.el
@@ -79,8 +79,8 @@ visibility, press <C-x d> to remove all active letterboxes."
   :group 'convenience)
 
 (defface letterbox-face
-  '(t (:background (face-attribute 'default :foreground)
-       :foreground (face-attribute 'default :foreground)))
+  `((t :background ,(face-attribute 'default :foreground)
+       :foreground ,(face-attribute 'default :foreground)))
   "Letterbox mode face."
   :group 'letterbox)
 


### PR DESCRIPTION
There is a similar package up for review here: https://github.com/melpa/melpa/pull/8223

In looking for similarities I took a look at this package.  However, in emacs 28.1 when running the form
```elisp
(defface letterbox-face
  '(t (:background (face-attribute 'default :foreground)
       :foreground (face-attribute 'default :foreground)))
  "Letterbox mode face."
  :group 'letterbox)
```
we get the following error:
```elisp
Loading letterbox-mode.el
  letterbox-mode.el:Error: Emacs 28.1:
  (wrong-type-argument listp t)
```
